### PR TITLE
fix: 忽略嵌套工作树目录条目，避免快照枚举抛 INVALID_PATH

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -21,7 +21,14 @@ export async function discoverRepository(cwd, signal) {
         throw new ChangeLedgerError('SUBMODULE_UNSUPPORTED', `submodules require independent restore points; unsupported gitlinks: ${submodules.slice(0, 10).join(', ')}`);
     }
     const pathOutput = await git(root, ['ls-files', '-z', '--cached', '--others', '--exclude-standard'], signal);
-    const paths = [...new Set(splitNul(pathOutput).map(validateRelativePath))].sort(comparePaths);
+    // `ls-files --others` refuses to descend into embedded repositories, such as a
+    // linked worktree nested inside this checkout; it reports the directory itself
+    // with a trailing slash (for example `nested/`). Those directories are separate
+    // checkouts, not files of this worktree, so exclude them from the snapshot
+    // inventory instead of rejecting the entry as a non-canonical path.
+    const paths = [...new Set(splitNul(pathOutput)
+            .filter((path) => !path.endsWith('/'))
+            .map(validateRelativePath))].sort(comparePaths);
     const head = trimOptional(await gitOptional(root, ['rev-parse', '--verify', '--quiet', 'HEAD'], signal));
     const branch = trimOptional(await gitOptional(root, ['symbolic-ref', '--quiet', '--short', 'HEAD'], signal));
     const stagedOutput = await git(root, ['diff', '--cached', '--name-only', '-z'], signal);

--- a/src/git.ts
+++ b/src/git.ts
@@ -37,7 +37,14 @@ export async function discoverRepository(cwd: string, signal?: AbortSignal): Pro
   }
 
   const pathOutput = await git(root, ['ls-files', '-z', '--cached', '--others', '--exclude-standard'], signal)
-  const paths = [...new Set(splitNul(pathOutput).map(validateRelativePath))].sort(comparePaths)
+  // `ls-files --others` refuses to descend into embedded repositories, such as a
+  // linked worktree nested inside this checkout; it reports the directory itself
+  // with a trailing slash (for example `nested/`). Those directories are separate
+  // checkouts, not files of this worktree, so exclude them from the snapshot
+  // inventory instead of rejecting the entry as a non-canonical path.
+  const paths = [...new Set(splitNul(pathOutput)
+    .filter((path) => !path.endsWith('/'))
+    .map(validateRelativePath))].sort(comparePaths)
   const head = trimOptional(await gitOptional(root, ['rev-parse', '--verify', '--quiet', 'HEAD'], signal))
   const branch = trimOptional(await gitOptional(root, ['symbolic-ref', '--quiet', '--short', 'HEAD'], signal))
   const stagedOutput = await git(root, ['diff', '--cached', '--name-only', '-z'], signal)

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -122,6 +122,21 @@ test('turn checkpoint retention prunes only the oldest checkpoint in the same se
   )
 })
 
+test('a nested linked worktree is excluded from the snapshot instead of failing path validation', async (t) => {
+  const f = await fixture()
+  t.after(f.cleanup)
+  await seedCommitted(f.workspace, { 'src/main.txt': 'alpha\n' })
+  await git(f.workspace, 'worktree', 'add', 'nested', '-b', 'topic/agent')
+  await writeFile(join(f.workspace, 'nested', 'inner.txt'), 'inner checkout\n')
+
+  const point = await f.engine.create({ cwd: f.workspace, sessionId: 'session-a' })
+  assert.equal(point.fileCount, 1)
+  const manifest = await f.engine.store.readManifest(await realpath(f.workspace), point.id)
+  assert.deepEqual(Object.keys(manifest.entries), ['src/main.txt'])
+  const inspection = await f.engine.inspect({ cwd: f.workspace, restorePointId: point.id })
+  assert.equal(inspection.changes.length, 0)
+})
+
 test('worktree discovery preserves legal trailing spaces in the root path', async (t) => {
   const outer = await mkdtemp(join(tmpdir(), 'dsh-change-ledger-space-test-'))
   t.after(async () => rm(outer, { recursive: true, force: true }))


### PR DESCRIPTION
## 问题

工作区包含嵌套 linked worktree（例如 Claude Code 的 `.claude/worktrees/agent-*`）时，每一轮 Turn Rewind 检查点捕获都会失败：

```text
[INVALID_PATH] path is not canonical: ".claude/worktrees/agent-a3078e170b63517a3/"
```

## 根因

`discoverRepository` 通过 `git ls-files -z --cached --others --exclude-standard` 枚举路径。`ls-files --others` 不会下探嵌入式仓库（目录内含有 `.git` 的嵌套工作树/克隆），而是把目录本身以尾斜杠形式输出（如 `nested/`）。该条目随后被 `validateRelativePath` 拒绝，导致整个快照枚举抛 `INVALID_PATH`，检查点永不落盘。

## 修复

在路径枚举边界排除尾斜杠目录条目：它们是独立检出，并非本工作区的文件。持久化路径校验保持不变——带尾斜杠的持久化路径仍然会被拒绝（符合 AGENTS.md 中不得把畸形持久化路径洗白为合法路径的要求）。

## 测试

新增回归测试：在临时仓库中真实执行 `git worktree add` 创建嵌套工作树，验证 `engine.create` 成功、快照 entries 不含外部检出文件、`inspect` 无差异。

本地验证：`tsc` 通过；engine 测试 25 通过 / 3 失败，3 个失败均为 Windows 环境限制（symlink EPERM ×2、目录名尾空格被 Windows 剥离），与本次修改无关，Linux CI 不受影响。