### PR TITLE
fix: isolate turn checkpoints from session response flow

### DIFF
--- a/lib/rewind-host.js
+++ b/lib/rewind-host.js
@@ -6,7 +6,7 @@ export const REWIND_HTTP_PATH = '/turn-rewind';
 const BODY_LIMIT = 64 * 1024;
 const INITIAL_CHANGE_PREVIEW_LIMIT = 8;
 const MAX_CHANGE_PAGE_SIZE = 200;
-/** Capture each turn before its opening user message can trigger model or tool work. */
+/** Capture each turn beside model work and before its first root tool side effect. */
 export class TurnCheckpointCoordinator {
     engine;
     captures = new Map();
@@ -17,11 +17,17 @@ export class TurnCheckpointCoordinator {
     constructor(engine) {
         this.engine = engine;
     }
-    /** Install the first-step gate; checkpoint failures are recorded but never reject the user turn. */
+    /** Keep sidecar checkpoint work out of the Agent response waterfall. */
     install(ctx) {
         ctx.on('agent/pre-step', async ({ agent, turn, step, signal }, next) => {
             if (step === 1)
-                await this.capture(ctx, agent, turn, signal);
+                this.startCapture(ctx, agent, turn, signal);
+            return next();
+        }, { prepend: true });
+        ctx.on('tools/execute', async (exec, next) => {
+            if (exec.agent !== undefined && exec.parent === undefined) {
+                await this.waitForOpenTurn(exec.agent, exec.signal);
+            }
             return next();
         }, { prepend: true });
     }
@@ -35,6 +41,15 @@ export class TurnCheckpointCoordinator {
             return { status: 'skipped', reason };
         const error = this.failures.get(key);
         return error === undefined ? { status: 'missing' } : { status: 'failed', error };
+    }
+    startCapture(ctx, agent, turn, signal) {
+        const key = checkpointKey(agent.id, turn);
+        if (this.captures.has(key))
+            return;
+        const capture = this.capture(ctx, agent, turn, signal).catch(async (error) => {
+            await this.recordFailure(ctx, agent.id, turn, error);
+        });
+        this.captures.set(key, capture);
     }
     async capture(ctx, agent, turn, signal) {
         const key = checkpointKey(agent.id, turn);
@@ -53,11 +68,6 @@ export class TurnCheckpointCoordinator {
         const captureDeadline = createDeadline(Math.max(1, timeoutMs - reserveMs));
         const captureSignal = AbortSignal.any([signal, captureDeadline.signal]);
         try {
-            const existing = this.captures.get(key);
-            if (existing !== undefined) {
-                await waitWithSignal(existing, captureSignal).catch(() => undefined);
-                return;
-            }
             this.pending.add(key);
             this.failures.delete(key);
             this.skips.delete(key);
@@ -86,7 +96,6 @@ export class TurnCheckpointCoordinator {
                     this.pending.delete(key);
                 }
             })();
-            this.captures.set(key, capture);
             try {
                 await waitWithSignal(capture, outcomeSignal);
             }
@@ -106,6 +115,20 @@ export class TurnCheckpointCoordinator {
             captureDeadline.cancel();
             outcomeDeadline.cancel();
         }
+    }
+    /** Wait only for the bounded checkpoint outcome of the Agent's open turn. */
+    async waitForOpenTurn(agent, signal) {
+        signal.throwIfAborted();
+        const boundary = agent.session.events.findLast(event => event.type === 'turn/start' || event.type === 'turn/end');
+        if (boundary?.type !== 'turn/start')
+            return;
+        const turn = boundary.data.turn;
+        if (!Number.isSafeInteger(turn) || turn < 0)
+            return;
+        const capture = this.captures.get(checkpointKey(agent.id, turn));
+        if (capture !== undefined)
+            await waitWithSignal(capture, signal);
+        signal.throwIfAborted();
     }
     async serializeWorkspace(workspace, signal, task) {
         const previous = this.workspaceTails.get(workspace) ?? Promise.resolve();

--- a/lib/types/rewind-host.d.ts
+++ b/lib/types/rewind-host.d.ts
@@ -20,6 +20,11 @@ interface AgentLike {
     readonly status: 'idle' | 'running';
     readonly session: SessionLike;
 }
+interface ToolExecutionLike {
+    readonly agent?: AgentLike;
+    readonly parent?: symbol;
+    readonly signal: AbortSignal;
+}
 interface AgentsLike {
     list(): AgentLike[];
 }
@@ -106,10 +111,11 @@ declare module '@deepseek-ai/cordis' {
             readonly step: number;
             readonly signal: AbortSignal;
         }, next: () => Promise<unknown>): Promise<unknown>;
+        'tools/execute'(exec: ToolExecutionLike, next: () => Promise<unknown>): Promise<unknown>;
     }
 }
 export declare const REWIND_HTTP_PATH = "/turn-rewind";
-/** Capture each turn before its opening user message can trigger model or tool work. */
+/** Capture each turn beside model work and before its first root tool side effect. */
 export declare class TurnCheckpointCoordinator {
     private readonly engine;
     private readonly captures;
@@ -118,7 +124,7 @@ export declare class TurnCheckpointCoordinator {
     private readonly skips;
     private readonly workspaceTails;
     constructor(engine: ChangeLedgerEngine);
-    /** Install the first-step gate; checkpoint failures are recorded but never reject the user turn. */
+    /** Keep sidecar checkpoint work out of the Agent response waterfall. */
     install(ctx: Context): void;
     /** Current capture state for a session turn when no durable checkpoint exists yet. */
     state(sessionId: string, turn: number): {
@@ -126,7 +132,10 @@ export declare class TurnCheckpointCoordinator {
         readonly error?: string;
         readonly reason?: string;
     };
+    private startCapture;
     private capture;
+    /** Wait only for the bounded checkpoint outcome of the Agent's open turn. */
+    private waitForOpenTurn;
     private serializeWorkspace;
     private recordFailure;
 }

--- a/src/rewind-host.ts
+++ b/src/rewind-host.ts
@@ -29,6 +29,12 @@ interface AgentLike {
   readonly session: SessionLike
 }
 
+interface ToolExecutionLike {
+  readonly agent?: AgentLike
+  readonly parent?: symbol
+  readonly signal: AbortSignal
+}
+
 interface AgentsLike {
   list(): AgentLike[]
 }
@@ -102,6 +108,10 @@ declare module '@deepseek-ai/cordis' {
       },
       next: () => Promise<unknown>,
     ): Promise<unknown>
+    'tools/execute'(
+      exec: ToolExecutionLike,
+      next: () => Promise<unknown>,
+    ): Promise<unknown>
   }
 }
 
@@ -110,7 +120,7 @@ const BODY_LIMIT = 64 * 1024
 const INITIAL_CHANGE_PREVIEW_LIMIT = 8
 const MAX_CHANGE_PAGE_SIZE = 200
 
-/** Capture each turn before its opening user message can trigger model or tool work. */
+/** Capture each turn beside model work and before its first root tool side effect. */
 export class TurnCheckpointCoordinator {
   private readonly captures = new Map<string, Promise<void>>()
   private readonly pending = new Set<string>()
@@ -120,10 +130,17 @@ export class TurnCheckpointCoordinator {
 
   constructor(private readonly engine: ChangeLedgerEngine) {}
 
-  /** Install the first-step gate; checkpoint failures are recorded but never reject the user turn. */
+  /** Keep sidecar checkpoint work out of the Agent response waterfall. */
   install(ctx: Context): void {
     ctx.on('agent/pre-step', async ({ agent, turn, step, signal }, next) => {
-      if (step === 1) await this.capture(ctx, agent, turn, signal)
+      if (step === 1) this.startCapture(ctx, agent, turn, signal)
+      return next()
+    }, { prepend: true })
+
+    ctx.on('tools/execute', async (exec, next) => {
+      if (exec.agent !== undefined && exec.parent === undefined) {
+        await this.waitForOpenTurn(exec.agent, exec.signal)
+      }
       return next()
     }, { prepend: true })
   }
@@ -136,6 +153,20 @@ export class TurnCheckpointCoordinator {
     if (reason !== undefined) return { status: 'skipped', reason }
     const error = this.failures.get(key)
     return error === undefined ? { status: 'missing' } : { status: 'failed', error }
+  }
+
+  private startCapture(
+    ctx: Pick<Context, 'logger'>,
+    agent: AgentLike,
+    turn: number,
+    signal: AbortSignal,
+  ): void {
+    const key = checkpointKey(agent.id, turn)
+    if (this.captures.has(key)) return
+    const capture = this.capture(ctx, agent, turn, signal).catch(async (error: unknown) => {
+      await this.recordFailure(ctx, agent.id, turn, error)
+    })
+    this.captures.set(key, capture)
   }
 
   private async capture(
@@ -159,11 +190,6 @@ export class TurnCheckpointCoordinator {
     const captureDeadline = createDeadline(Math.max(1, timeoutMs - reserveMs))
     const captureSignal = AbortSignal.any([signal, captureDeadline.signal])
     try {
-      const existing = this.captures.get(key)
-      if (existing !== undefined) {
-        await waitWithSignal(existing, captureSignal).catch(() => undefined)
-        return
-      }
       this.pending.add(key)
       this.failures.delete(key)
       this.skips.delete(key)
@@ -201,7 +227,6 @@ export class TurnCheckpointCoordinator {
           this.pending.delete(key)
         }
       })()
-      this.captures.set(key, capture)
       try {
         await waitWithSignal(capture, outcomeSignal)
       } catch (error) {
@@ -218,6 +243,18 @@ export class TurnCheckpointCoordinator {
       captureDeadline.cancel()
       outcomeDeadline.cancel()
     }
+  }
+
+  /** Wait only for the bounded checkpoint outcome of the Agent's open turn. */
+  private async waitForOpenTurn(agent: AgentLike, signal: AbortSignal): Promise<void> {
+    signal.throwIfAborted()
+    const boundary = agent.session.events.findLast(event => event.type === 'turn/start' || event.type === 'turn/end')
+    if (boundary?.type !== 'turn/start') return
+    const turn = boundary.data.turn
+    if (!Number.isSafeInteger(turn) || (turn as number) < 0) return
+    const capture = this.captures.get(checkpointKey(agent.id, turn as number))
+    if (capture !== undefined) await waitWithSignal(capture, signal)
+    signal.throwIfAborted()
   }
 
   private async serializeWorkspace(workspace: string, signal: AbortSignal, task: () => Promise<void>): Promise<void> {

--- a/tests/rewind-host.test.mjs
+++ b/tests/rewind-host.test.mjs
@@ -56,25 +56,49 @@ async function git(cwd, ...args) {
   })
 }
 
-test('first-step checkpoint finishes before the user turn continues', async (t) => {
+test('first-step checkpoint stays off the response path but gates the first root tool', async (t) => {
   const f = await fixture()
   t.after(f.cleanup)
   const agent = preStepAgent('session-web', f.workspace, 2, 8)
-  const { coordinator, listener } = installedCoordinator(f.engine)
-  let visibleBeforeNext = false
+  const original = f.engine.createTurnCheckpoint.bind(f.engine)
+  const captureStarted = Promise.withResolvers()
+  const captureRelease = Promise.withResolvers()
+  f.engine.createTurnCheckpoint = async (options) => {
+    captureStarted.resolve()
+    await captureRelease.promise
+    return original(options)
+  }
+  const { coordinator, listener, toolListener } = installedCoordinator(f.engine)
+  let turnContinued = false
 
   const decision = await listener(
     { agent, turn: 2, step: 1, signal: new AbortController().signal },
     async () => {
-      visibleBeforeNext = (await f.engine.findTurnCheckpoint({
-        cwd: f.workspace, sessionId: agent.id, turn: 2,
-      })) !== undefined
-      return { kind: 'enter' }
+      turnContinued = true
+      return { kind: 'enter', messages: [{ role: 'user', content: 'unchanged' }] }
     },
   )
+  await captureStarted.promise
 
-  assert.deepEqual(decision, { kind: 'enter' })
-  assert.equal(visibleBeforeNext, true)
+  assert.deepEqual(decision, { kind: 'enter', messages: [{ role: 'user', content: 'unchanged' }] })
+  assert.equal(turnContinued, true)
+  assert.equal(coordinator.state(agent.id, 2).status, 'pending')
+
+  assert.deepEqual(await toolListener(
+    { agent, parent: Symbol('nested-call'), signal: new AbortController().signal },
+    async () => ({ nested: true }),
+  ), { nested: true })
+
+  let toolContinued = false
+  const tool = toolListener(
+    { agent, signal: new AbortController().signal },
+    async () => { toolContinued = true; return { isError: false } },
+  )
+  await new Promise(resolve => setTimeout(resolve, 10))
+  assert.equal(toolContinued, false)
+  captureRelease.resolve()
+  assert.deepEqual(await tool, { isError: false })
+  assert.equal(toolContinued, true)
   assert.equal((await f.engine.findTurnCheckpoint({
     cwd: f.workspace, sessionId: agent.id, turn: 2,
   }))?.turnStartSeq, 8)
@@ -105,7 +129,7 @@ test('checkpoint capture serializes one worktree and failure never blocks the tu
     }
   }
   const warnings = []
-  const { coordinator, listener } = installedCoordinator(f.engine, warnings)
+  const { coordinator, listener, toolListener } = installedCoordinator(f.engine, warnings)
   const first = preStepAgent('session-one', f.workspace, 1, 1)
   const second = preStepAgent('session-two', nested, 2, 8)
   const failed = preStepAgent('session-failed', f.workspace, 3, 12)
@@ -119,6 +143,10 @@ test('checkpoint capture serializes one worktree and failure never blocks the tu
     { agent: failed, turn: 3, step: 1, signal: new AbortController().signal },
     async () => { continued += 1; return { kind: 'enter' } },
   )
+  await Promise.all([first, second, failed].map(agent => toolListener(
+    { agent, signal: new AbortController().signal },
+    async () => ({ isError: false }),
+  )))
 
   assert.equal(maxActive, 1)
   assert.equal(failedAttempts, 1)
@@ -135,7 +163,7 @@ test('bounded automatic checkpoint skips are visible and never block the turn', 
     throw new ChangeLedgerError('TURN_CHECKPOINT_TIMEOUT', 'automatic checkpoint exceeded 5 ms')
   }
   const warnings = []
-  const { coordinator, listener } = installedCoordinator(f.engine, warnings)
+  const { coordinator, listener, toolListener } = installedCoordinator(f.engine, warnings)
   const agent = preStepAgent('session-skipped', f.workspace, 4, 20)
   let continued = false
   await listener(
@@ -143,12 +171,16 @@ test('bounded automatic checkpoint skips are visible and never block the turn', 
     async () => { continued = true; return { kind: 'enter' } },
   )
   assert.equal(continued, true)
+  await toolListener(
+    { agent, signal: new AbortController().signal },
+    async () => ({ isError: false }),
+  )
   assert.equal(coordinator.state(agent.id, 4).status, 'skipped')
   assert.match(coordinator.state(agent.id, 4).reason, /TURN_CHECKPOINT_TIMEOUT/)
   assert.equal(warnings.length, 1)
 })
 
-test('the first-step gate waits for a skipped outcome to become durable', async (t) => {
+test('the response continues while the first root tool waits for durable skip recording', async (t) => {
   const f = await fixture()
   t.after(f.cleanup)
   f.engine.createTurnCheckpoint = async () => {
@@ -163,19 +195,26 @@ test('the first-step gate waits for a skipped outcome to become durable', async 
     await persistence
     persisted = true
   }
-  const { listener } = installedCoordinator(f.engine)
+  const { listener, toolListener } = installedCoordinator(f.engine)
   const agent = preStepAgent('session-skip-durable-gate', f.workspace, 4, 20)
   let continued = false
-  const invocation = listener(
+  await listener(
     { agent, turn: 4, step: 1, signal: new AbortController().signal },
     async () => { continued = true; return { kind: 'enter' } },
   )
   while (!persistenceStarted) await new Promise((resolve) => setTimeout(resolve, 1))
-  assert.equal(continued, false)
+  assert.equal(continued, true)
+  let toolContinued = false
+  const invocation = toolListener(
+    { agent, signal: new AbortController().signal },
+    async () => { toolContinued = true; return { isError: false } },
+  )
+  await new Promise(resolve => setTimeout(resolve, 10))
+  assert.equal(toolContinued, false)
   releasePersistence()
   await invocation
   assert.equal(persisted, true)
-  assert.equal(continued, true)
+  assert.equal(toolContinued, true)
 })
 
 test('the checkpoint deadline covers coordinator discovery and engine metadata reads', async (t) => {
@@ -189,15 +228,19 @@ test('the checkpoint deadline covers coordinator discovery and engine metadata r
   await bounded.initialize()
   bounded.store.listManifests = async () => new Promise(() => {})
   bounded.recordTurnCheckpointSkip = async () => {}
-  const { coordinator, listener } = installedCoordinator(bounded)
+  const { coordinator, listener, toolListener } = installedCoordinator(bounded)
   const agent = preStepAgent('session-coordinator-deadline', f.workspace, 4, 20)
   let continued = false
-  const startedAt = Date.now()
   await listener(
     { agent, turn: 4, step: 1, signal: new AbortController().signal },
     async () => { continued = true; return { kind: 'enter' } },
   )
   assert.equal(continued, true)
+  const startedAt = Date.now()
+  await toolListener(
+    { agent, signal: new AbortController().signal },
+    async () => ({ isError: false }),
+  )
   assert.equal(coordinator.state(agent.id, 4).status, 'skipped')
   assert.ok(Date.now() - startedAt < 600)
   await Promise.all(coordinator.captures.values())
@@ -220,15 +263,19 @@ test('slow durable skip persistence cannot extend the pre-step deadline', async 
     await new Promise((resolve) => setTimeout(resolve, 450))
     persistenceFinished = true
   }
-  const { coordinator, listener } = installedCoordinator(bounded)
+  const { coordinator, listener, toolListener } = installedCoordinator(bounded)
   const agent = preStepAgent('session-slow-outcome', f.workspace, 4, 20)
   let continued = false
-  const startedAt = Date.now()
   await listener(
     { agent, turn: 4, step: 1, signal: new AbortController().signal },
     async () => { continued = true; return { kind: 'enter' } },
   )
   assert.equal(continued, true)
+  const startedAt = Date.now()
+  await toolListener(
+    { agent, signal: new AbortController().signal },
+    async () => ({ isError: false }),
+  )
   assert.equal(coordinator.state(agent.id, 4).status, 'skipped')
   assert.ok(Date.now() - startedAt < 250)
   while (!persistenceFinished) await new Promise((resolve) => setTimeout(resolve, 10))
@@ -693,11 +740,17 @@ function preStepAgent(id, cwd, turn, startSeq) {
 
 function installedCoordinator(engine, warnings = []) {
   let listener
+  let toolListener
   const coordinator = new TurnCheckpointCoordinator(engine)
   coordinator.install({
     logger: { warn(value) { warnings.push(value) } },
-    on(name, value) { if (name === 'agent/pre-step') listener = value; return () => {} },
+    on(name, value) {
+      if (name === 'agent/pre-step') listener = value
+      if (name === 'tools/execute') toolListener = value
+      return () => {}
+    },
   })
   assert.equal(typeof listener, 'function')
-  return { coordinator, listener }
+  assert.equal(typeof toolListener, 'function')
+  return { coordinator, listener, toolListener }
 }


### PR DESCRIPTION
## Summary

- start automatic turn checkpoint capture beside the first model request instead of awaiting it inside the `agent/pre-step` response waterfall
- gate only the first root tool dispatch on the bounded checkpoint outcome, preserving the pre-turn file snapshot before tool side effects
- leave nested tool calls alone and preserve timeout/skip durability behavior
- regenerate the installable `lib/` runtime and declarations

## Why

Issue #13 reports that sessions can fail to load after using rewind and restarting DSH. Turn checkpoint work is sidecar state and should not participate in the Agent response/persistence waterfall. This change separates that work from the session response path while retaining the safety boundary before root tools can mutate files.

Closes #13.

## Verification

- `pnpm run check`
  - TypeScript checks passed
  - build passed
  - 102/102 tests passed
  - package dry-run passed
- focused `tests/rewind-host.test.mjs`
  - pre-step decision passes through unchanged while capture remains pending
  - first root tool waits for capture
  - nested tools do not wait
  - failed and skipped captures do not block the response
  - checkpoint and slow skip-persistence deadlines remain bounded

## Browser / real-user verification

Tested with DSH `0.1.1-rc.1` in an isolated Web profile at `http://127.0.0.1:3093`:

1. Created a fresh workspace session.
2. Asked the Agent to replace `note.txt` (`baseline`) with `changed by issue 13 E2E`.
3. Opened the user-message rewind action.
4. Selected **只恢复文件** and applied the restore.
5. Verified `note.txt` returned to `baseline` and the UI reported completion.
6. Restarted the DSH process.
7. Reopened the same session and verified its full conversation and rewind action loaded normally.
8. Inspected the persisted session artifact: 64 records, zero Turn Rewind-specific records/fields; event envelopes remained official DSH shapes.
