### PR TITLE
fix: declare latest DSH release compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-turn-rewind",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Turn-level conversation and workspace rewind for DeepSeek Harness, powered by a persistent Change Ledger",
   "repository": {
     "type": "git",
@@ -56,6 +56,17 @@
       "inject": [
         "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-ui-conversation"
+      ]
+    },
+    "compatibility": {
+      "dsh": ">=0.1.0-rc.8 <0.2.0",
+      "dshReleases": {
+        "0.1.0-rc.8": "compatible",
+        "0.1.1-rc.1": "compatible",
+        "0.1.1-rc.2": "compatible"
+      },
+      "profiles": [
+        "web"
       ]
     }
   },

--- a/tests/package-layout.test.mjs
+++ b/tests/package-layout.test.mjs
@@ -20,6 +20,15 @@ test('package is a portable, prebuilt DSH Profile Bundle', async () => {
       '@deepseek-ai/dsh-client-ui-conversation',
     ],
   })
+  assert.deepEqual(pkg.dsh?.compatibility, {
+    dsh: '>=0.1.0-rc.8 <0.2.0',
+    dshReleases: {
+      '0.1.0-rc.8': 'compatible',
+      '0.1.1-rc.1': 'compatible',
+      '0.1.1-rc.2': 'compatible',
+    },
+    profiles: ['web'],
+  })
   assert.equal(pkg.dshClient, undefined)
   assert.equal(pkg.main, 'lib/index.js')
   assert.equal(pkg.types, 'lib/types/index.d.ts')


### PR DESCRIPTION
## Summary

- bump the bundle manifest version from `0.1.2` to `0.1.3`
- declare the supported DSH range as `>=0.1.0-rc.8 <0.2.0`
- add exact `compatible` records for `0.1.0-rc.8`, `0.1.1-rc.1`, and `0.1.1-rc.2`
- lock the compatibility contract into the package-layout test

This addresses the upstream compatibility hold reported in AI-Scarlett/DSH-Store#269. DSH STORE can discover the new fixed Commit after this PR reaches the default branch; no Registry edit is required.

## Verification

- `pnpm run check` — 102 tests passed, TypeScript/build passed, and `pnpm pack --dry-run` passed
- DSH STORE candidate-retention evaluator — recognized the manifest as `compatible`
- `build-dsh-plugin` static audit — `isolated-acceptance-ready`, 78/80, no blockers
- final packed `@anionex/dsh-turn-rewind@0.1.3` disposable Web Profile matrix:
  - DSH `0.1.0-rc.8`: install, dump-config, cold start, Host route, Client bundle, uninstall passed
  - DSH `0.1.1-rc.1`: install, dump-config, cold start, Host route, Client bundle, uninstall passed
  - DSH `0.1.1-rc.2`: install, dump-config, cold start, Host route, Client bundle, uninstall passed
- every disposable `DSH_HOME` was removed after verification; no real user Profile was modified

## UI verification

This PR changes manifest metadata only and does not change UI behavior. As a runtime substitute, each supported DSH version served the Web application, exposed the Turn Rewind Client bundle, included the plugin in the browser bootstrap, and returned the expected validation error from the Host route.
